### PR TITLE
support for invokable controllers

### DIFF
--- a/src/DefinitionFile.php
+++ b/src/DefinitionFile.php
@@ -95,7 +95,9 @@ class DefinitionFile implements Arrayable
 
     private function createPathEntry(Route $route): void
     {
-        [$controller, $methodName] = explode('@', $route->getActionName());
+        $controller = $route->getControllerClass();
+        $methodName = is_callable($route->getController()) ? '__invoke' : $route->getActionMethod();
+        
         $controllerReflector = new ReflectionClass($controller);
         $controllerMethod = $controllerReflector->getMethod($methodName);
 


### PR DESCRIPTION
checking if controller class is invokable during path entry creation.
Currently the application breaks at Hypnodev\OpenapiGenerator\DefinitionFile@createPathEntry at `[$controller, $methodName] = explode('@', $route->getActionName())`, since an invokable controller won't have any "@"