### PR TITLE
[FEATURE ]support for custom prefixes

### DIFF
--- a/src/Commands/OpenApiGenerate.php
+++ b/src/Commands/OpenApiGenerate.php
@@ -55,8 +55,10 @@ class OpenApiGenerate extends Command
 
         $this->info('Generating OpenApi specification...');
 
+        $prefix = $this->argument('prefix')??'api';
+
         try {
-            $definitions = OpenapiGenerator::make();
+            $definitions = OpenapiGenerator::make($prefix);
             file_put_contents(
                 $output,
                 Yaml::dump($definitions, flags: Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE)

--- a/src/OpenapiGenerator.php
+++ b/src/OpenapiGenerator.php
@@ -4,7 +4,6 @@ namespace Hypnodev\OpenapiGenerator;
 
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Route as Router;
-use Illuminate\Support\Str;
 
 class OpenapiGenerator
 {
@@ -16,10 +15,14 @@ class OpenapiGenerator
 
     public function make(string $prefix = 'api'): array
     {
-        $routes = collect(Router::getRoutes())->filter(function (Route $route) use ($prefix) {
-            return in_array('api', $route->middleware(), true)
-                && $route->getActionName() !== 'Closure';
-        });
+        $regex = preg_quote(trim($prefix, '/'), '/');
+        $routeFilter = fn (Route $route) =>
+        preg_match('/^' . $regex . '((\/.+)|$)/', $route->uri,)
+            &&
+            $route->getActionName() !== 'Closure';
+            
+        $routes = collect(Router::getRoutes())
+            ->filter($routeFilter);
 
         $definitionFile = new DefinitionFile($this->metadata);
         $definitionFile->routes($routes);


### PR DESCRIPTION
adding the ability to customise route prefix before generating openapi doc. 
I had some test coverage in pest, I didn't add it to the commit since I didn't wanna add a dev dependency in the very same pr that is adding new features. I think this feature is ok for now, maybe in the long run it is worth giving the user the ability to set a custom route filter.